### PR TITLE
add python3-compatibility to the alignment utiliy

### DIFF
--- a/src/align/detect_face.py
+++ b/src/align/detect_face.py
@@ -506,19 +506,19 @@ def pad(total_boxes, w, h):
     ey = total_boxes[:,3].copy().astype(np.int32)
 
     tmp = np.where(ex>w)
-    edx[tmp] = np.expand_dims(-ex[tmp]+w+tmpw[tmp],1)
+    edx.flat[tmp] = np.expand_dims(-ex[tmp]+w+tmpw[tmp],1)
     ex[tmp] = w
     
     tmp = np.where(ey>h)
-    edy[tmp] = np.expand_dims(-ey[tmp]+h+tmph[tmp],1)
+    edy.flat[tmp] = np.expand_dims(-ey[tmp]+h+tmph[tmp],1)
     ey[tmp] = h
 
     tmp = np.where(x<1)
-    dx[tmp] = np.expand_dims(2-x[tmp],1)
+    dx.flat[tmp] = np.expand_dims(2-x[tmp],1)
     x[tmp] = 1
 
     tmp = np.where(y<1)
-    dy[tmp] = np.expand_dims(2-y[tmp],1)
+    dy.flat[tmp] = np.expand_dims(2-y[tmp],1)
     y[tmp] = 1
     
     return dy, edy, dx, edx, y, ey, x, ex, tmpw, tmph

--- a/src/align/detect_face.py
+++ b/src/align/detect_face.py
@@ -26,6 +26,7 @@ https://github.com/kpzhang93/MTCNN_face_detection_alignment
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+from six import string_types, iteritems
 
 import numpy as np
 import tensorflow as tf
@@ -81,10 +82,11 @@ class Network(object):
         session: The current TensorFlow session
         ignore_missing: If true, serialized weights for missing layers are ignored.
         '''
-        data_dict = np.load(data_path).item() #pylint: disable=no-member
+        data_dict = np.load(data_path, encoding='latin1').item() #pylint: disable=no-member
+
         for op_name in data_dict:
             with tf.variable_scope(op_name, reuse=True):
-                for param_name, data in data_dict[op_name].iteritems():
+                for param_name, data in iteritems(data_dict[op_name]):
                     try:
                         var = tf.get_variable(param_name)
                         session.run(var.assign(data))
@@ -99,7 +101,7 @@ class Network(object):
         assert len(args) != 0
         self.terminals = []
         for fed_layer in args:
-            if isinstance(fed_layer, basestring):
+            if isinstance(fed_layer, string_types):
                 try:
                     fed_layer = self.layers[fed_layer]
                 except KeyError:


### PR DESCRIPTION
1)  4bd9770
    Before: The alignment utility worked well on python 2.x but failed on python 3.x. 
    After: The modified version works well both on python 2/3.

2) 3fd12e8
    Before: Lots of warning were printed on the screen showing that there were unmatched ndarray shape assignment. 
    After: Suppress the warning as suggested.