### PR TITLE
Adding support for Python3 and Windows

### DIFF
--- a/src/facenet.py
+++ b/src/facenet.py
@@ -320,7 +320,7 @@ class ImageClass():
   
 def get_dataset(paths):
     dataset = []
-    for path in paths.split(':'):
+    for path in paths.split('|'):
         path_exp = os.path.expanduser(path)
         classes = os.listdir(path_exp)
         classes.sort()


### PR DESCRIPTION
Please note that I had to change the path delimiter to be "|" instead of ":", since it's breaking windows code.