### PR TITLE
Add python3 compatibility

### DIFF
--- a/src/align/detect_face.py
+++ b/src/align/detect_face.py
@@ -506,19 +506,19 @@ def pad(total_boxes, w, h):
     ey = total_boxes[:,3].copy().astype(np.int32)
 
     tmp = np.where(ex>w)
-    edx[tmp] = np.expand_dims(-ex[tmp]+w+tmpw[tmp],1)
+    edx.flat[tmp] = np.expand_dims(-ex[tmp]+w+tmpw[tmp],1)
     ex[tmp] = w
     
     tmp = np.where(ey>h)
-    edy[tmp] = np.expand_dims(-ey[tmp]+h+tmph[tmp],1)
+    edy.flat[tmp] = np.expand_dims(-ey[tmp]+h+tmph[tmp],1)
     ey[tmp] = h
 
     tmp = np.where(x<1)
-    dx[tmp] = np.expand_dims(2-x[tmp],1)
+    dx.flat[tmp] = np.expand_dims(2-x[tmp],1)
     x[tmp] = 1
 
     tmp = np.where(y<1)
-    dy[tmp] = np.expand_dims(2-y[tmp],1)
+    dy.flat[tmp] = np.expand_dims(2-y[tmp],1)
     y[tmp] = 1
     
     return dy, edy, dx, edx, y, ey, x, ex, tmpw, tmph

--- a/src/align/detect_face.py
+++ b/src/align/detect_face.py
@@ -26,6 +26,7 @@ https://github.com/kpzhang93/MTCNN_face_detection_alignment
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
+from six import string_types, iteritems
 
 import numpy as np
 import tensorflow as tf
@@ -81,10 +82,11 @@ class Network(object):
         session: The current TensorFlow session
         ignore_missing: If true, serialized weights for missing layers are ignored.
         '''
-        data_dict = np.load(data_path).item() #pylint: disable=no-member
+        data_dict = np.load(data_path, encoding='latin1').item() #pylint: disable=no-member
+
         for op_name in data_dict:
             with tf.variable_scope(op_name, reuse=True):
-                for param_name, data in data_dict[op_name].iteritems():
+                for param_name, data in iteritems(data_dict[op_name]):
                     try:
                         var = tf.get_variable(param_name)
                         session.run(var.assign(data))
@@ -99,7 +101,7 @@ class Network(object):
         assert len(args) != 0
         self.terminals = []
         for fed_layer in args:
-            if isinstance(fed_layer, basestring):
+            if isinstance(fed_layer, string_types):
                 try:
                     fed_layer = self.layers[fed_layer]
                 except KeyError:

--- a/src/facenet_train_classifier.py
+++ b/src/facenet_train_classifier.py
@@ -43,7 +43,7 @@ import h5py
 
 def main(args):
   
-    network = importlib.import_module(args.model_def, 'inference')
+    network = importlib.import_module(args.model_def)
 
     subdir = datetime.strftime(datetime.now(), '%Y%m%d-%H%M%S')
     log_dir = os.path.join(os.path.expanduser(args.logs_base_dir), subdir)


### PR DESCRIPTION
Before: 
The alignment utility and facenet_train_classifier worked on python 2.x but failed on python 3.x. 

After: 
works both on python 2 and 3.