### PR TITLE
consistent detect result

### DIFF
--- a/src/align/detect_face.py
+++ b/src/align/detect_face.py
@@ -303,7 +303,7 @@ def detect_face(img, minsize, pnet, rnet, onet, threshold, factor):
     # fastresize: resize img from last scale (using in high-resolution images) if fastresize==true
     factor_count=0
     total_boxes=np.empty((0,9))
-    points=[]
+    points=np.empty(0)
     h=img.shape[0]
     w=img.shape[1]
     minl=np.amin([h, w])


### PR DESCRIPTION
The return type of `points` in `detect_face()` is usually type of numpy array.
But when all three stages fail `points` is empty list `[]` which is a initial value.
This change keeps the type of `points` to numpy array.