### PR TITLE
enable Python 3 test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 sudo: required
 python:
   - "2.7"
+  - "3.5"
 # command to install dependencies
 install:
 # numpy not using wheel to avoid problem described in 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # Face Recognition using Tensorflow
+
+![Travis](http://travis-ci.org/davidsandberg/facenet.svg?branch=master)
+
 This is a TensorFlow implementation of the face recognizer described in the paper
 ["FaceNet: A Unified Embedding for Face Recognition and Clustering"](http://arxiv.org/abs/1503.03832). The project also uses ideas from the paper ["A Discriminative Feature Learning Approach for Deep Face Recognition"](http://ydwen.github.io/papers/WenECCV16.pdf) as well as the paper ["Deep Face Recognition"](http://www.robots.ox.ac.uk/~vgg/publications/2015/Parkhi15/parkhi15.pdf) from the [Visual Geometry Group](http://www.robots.ox.ac.uk/~vgg/) at Oxford.
 


### PR DESCRIPTION
It appears that the repo already supports Python 3? Let's re-enable the Python 3 tests.