### PR TITLE
allow loading pretained Inception

### DIFF
--- a/src/train_softmax.py
+++ b/src/train_softmax.py
@@ -205,7 +205,16 @@ def main(args):
 
             if pretrained_model:
                 print('Restoring pretrained model: %s' % pretrained_model)
-                saver.restore(sess, pretrained_model)
+                if args.checkpoint_exclude_scopes:
+                    exclusions = [args.checkpoint_exclude_scopes.split(',')]
+                else:
+                    exclusions = []
+                # load from pre-trained model
+                tf.contrib.framework.assign_from_checkpoint_fn(
+                    pretrained_model,
+                    [var for var in tf.trainable_variables()
+                        if all(not var.op.name.startswith(exclusion) for exclusion in exclusions)],
+                    ignore_missing_vars=args.ignore_missing_vars)(sess)
 
             # Training and validation loop
             print('Running training')
@@ -372,6 +381,10 @@ def parse_arguments(argv):
         help='Upper bound on the amount of GPU memory that will be used by the process.', default=1.0)
     parser.add_argument('--pretrained_model', type=str,
         help='Load a pretrained model before training starts.')
+    parser.add_argument('--ignore_missing_vars', action='store_true',
+        help='When restoring a checkpoint would ignore missing variables.')
+    parser.add_argument('--checkpoint_exclude_scopes', type=str,
+        help='Comma-separated list of scopes of variables to exclude when restoring from a checkpoint.')
     parser.add_argument('--data_dir', type=str,
         help='Path to the data directory containing aligned face patches. Multiple directories are separated with colon.',
         default='~/datasets/casia/casia_maxpy_mtcnnalign_182_160')


### PR DESCRIPTION
Sometimes one might want to finetune a Inception model pretrained on Imagenet. Such model does not contain the `Logits` fully-connected layer. Therefore, we must specify `ignore_missing_vars`. `checkpoint_exclude_scopes` could also be used to only load certain layers.