### PR TITLE
improve get_model_filenames() &  train_tripletloss.py &  compare.py

### DIFF
--- a/src/facenet.py
+++ b/src/facenet.py
@@ -397,6 +397,11 @@ def get_model_filenames(model_dir):
     elif len(meta_files)>1:
         raise ValueError('There should not be more than one meta file in the model directory (%s)' % model_dir)
     meta_file = meta_files[0]
+    ckpt = tf.train.get_checkpoint_state(model_dir)
+    if ckpt and ckpt.model_checkpoint_path:
+        ckpt_file = os.path.basename(ckpt.model_checkpoint_path)
+        return meta_file, ckpt_file
+
     meta_files = [s for s in files if '.ckpt' in s]
     max_step = -1
     for f in files:

--- a/src/train_tripletloss.py
+++ b/src/train_tripletloss.py
@@ -245,6 +245,7 @@ def train(args, sess, dataset, epoch, image_paths_placeholder, labels_placeholde
         i = 0
         emb_array = np.zeros((nrof_examples, embedding_size))
         loss_array = np.zeros((nrof_triplets,))
+        summary = tf.Summary()
         while i < nrof_batches:
             start_time = time.time()
             batch_size = min(nrof_examples-i*args.batch_size, args.batch_size)
@@ -258,9 +259,9 @@ def train(args, sess, dataset, epoch, image_paths_placeholder, labels_placeholde
             batch_number += 1
             i += 1
             train_time += duration
+            summary.value.add(tag='loss', simple_value=err)
             
         # Add validation loss and accuracy to summary
-        summary = tf.Summary()
         #pylint: disable=maybe-no-member
         summary.value.add(tag='time/selection', simple_value=selection_time)
         summary_writer.add_summary(summary, step)

--- a/src/train_tripletloss.py
+++ b/src/train_tripletloss.py
@@ -476,7 +476,7 @@ def parse_arguments(argv):
     parser.add_argument('--lfw_file_ext', type=str,
         help='The file extension for the LFW dataset.', default='png', choices=['jpg', 'png'])
     parser.add_argument('--lfw_dir', type=str,
-        help='Path to the data directory containing aligned face patches.', default='~/datasets/lfw/lfw_realigned/')
+        help='Path to the data directory containing aligned face patches.', default='')
     parser.add_argument('--lfw_nrof_folds', type=int,
         help='Number of folds to use for cross validation. Mainly used for testing.', default=10)
     return parser.parse_args(argv)


### PR DESCRIPTION
1. Previously get_model_filenames() will return the latest checkpoint but it's not always suitable. '${folder}/checkpoint' can indicate which checkpoint to loading, so will try to get checkpoint file name from this file at first and fall back to old solution if fails.
2. improve and fix some corner issues for train_tripletloss.py &  compare.py