### PR TITLE
Margin proportional to face dimensions

### DIFF
--- a/contributed/face.py
+++ b/contributed/face.py
@@ -38,6 +38,7 @@ import tensorflow as tf
 from scipy import misc
 
 import align.detect_face
+import align.utils
 import facenet
 
 
@@ -120,7 +121,7 @@ class Detection:
     threshold = [0.6, 0.7, 0.7]  # three steps's threshold
     factor = 0.709  # scale factor
 
-    def __init__(self, face_crop_size=160, face_crop_margin=32):
+    def __init__(self, face_crop_size=160, face_crop_margin=0.4):
         self.pnet, self.rnet, self.onet = self._setup_mtcnn()
         self.face_crop_size = face_crop_size
         self.face_crop_margin = face_crop_margin
@@ -142,15 +143,12 @@ class Detection:
             face = Face()
             face.container_image = image
             face.bounding_box = np.zeros(4, dtype=np.int32)
-
-            img_size = np.asarray(image.shape)[0:2]
-            face.bounding_box[0] = np.maximum(bb[0] - self.face_crop_margin / 2, 0)
-            face.bounding_box[1] = np.maximum(bb[1] - self.face_crop_margin / 2, 0)
-            face.bounding_box[2] = np.minimum(bb[2] + self.face_crop_margin / 2, img_size[1])
-            face.bounding_box[3] = np.minimum(bb[3] + self.face_crop_margin / 2, img_size[0])
-            cropped = image[face.bounding_box[1]:face.bounding_box[3], face.bounding_box[0]:face.bounding_box[2], :]
+            cropped, (x0, y0, x1, y1) = align.utils.crop(image, bb, self.face_crop_margin)
+            face.bounding_box[0] = x0
+            face.bounding_box[1] = y0
+            face.bounding_box[2] = x1
+            face.bounding_box[3] = y1
             face.image = misc.imresize(cropped, (self.face_crop_size, self.face_crop_size), interp='bilinear')
-
             faces.append(face)
 
         return faces

--- a/src/align/align_dataset_mtcnn.py
+++ b/src/align/align_dataset_mtcnn.py
@@ -35,6 +35,7 @@ import facenet
 import align.detect_face
 import random
 from time import sleep
+import utils
 
 def main(args):
     sleep(random.random())
@@ -114,7 +115,7 @@ def main(args):
                                 det_arr.append(np.squeeze(det))
 
                             for i, det in enumerate(det_arr):
-                                cropped, (x0, y0, x1, y1) = crop(img, np.squeeze(det), args.margin)
+                                cropped, (x0, y0, x1, y1) = utils.crop(img, np.squeeze(det), args.margin)
                                 scaled = misc.imresize(cropped, (args.image_size, args.image_size), interp='bilinear')
                                 nrof_successfully_aligned += 1
                                 filename_base, file_extension = os.path.splitext(output_filename)

--- a/src/align/align_dataset_mtcnn.py
+++ b/src/align/align_dataset_mtcnn.py
@@ -114,13 +114,7 @@ def main(args):
                                 det_arr.append(np.squeeze(det))
 
                             for i, det in enumerate(det_arr):
-                                det = np.squeeze(det)
-                                bb = np.zeros(4, dtype=np.int32)
-                                bb[0] = np.maximum(det[0]-args.margin/2, 0)
-                                bb[1] = np.maximum(det[1]-args.margin/2, 0)
-                                bb[2] = np.minimum(det[2]+args.margin/2, img_size[1])
-                                bb[3] = np.minimum(det[3]+args.margin/2, img_size[0])
-                                cropped = img[bb[1]:bb[3],bb[0]:bb[2],:]
+                                cropped, (x0, y0, x1, y1) = crop(img, np.squeeze(det), args.margin)
                                 scaled = misc.imresize(cropped, (args.image_size, args.image_size), interp='bilinear')
                                 nrof_successfully_aligned += 1
                                 filename_base, file_extension = os.path.splitext(output_filename)
@@ -129,7 +123,7 @@ def main(args):
                                 else:
                                     output_filename_n = "{}{}".format(filename_base, file_extension)
                                 misc.imsave(output_filename_n, scaled)
-                                text_file.write('%s %d %d %d %d\n' % (output_filename_n, bb[0], bb[1], bb[2], bb[3]))
+                                text_file.write('%s %d %d %d %d\n' % (output_filename_n, x0, y0, x1, y1))
                         else:
                             print('Unable to align "%s"' % image_path)
                             text_file.write('%s\n' % (output_filename))
@@ -145,8 +139,8 @@ def parse_arguments(argv):
     parser.add_argument('output_dir', type=str, help='Directory with aligned face thumbnails.')
     parser.add_argument('--image_size', type=int,
         help='Image size (height, width) in pixels.', default=182)
-    parser.add_argument('--margin', type=int,
-        help='Margin for the crop around the bounding box (height, width) in pixels.', default=44)
+    parser.add_argument('--margin', type=float,
+        help='Margin for the crop around the bounding box (height, width), as a proportion of the face height/width', default=.4)
     parser.add_argument('--random_order', 
         help='Shuffles the order of images to enable alignment using multiple processes.', action='store_true')
     parser.add_argument('--gpu_memory_fraction', type=float,

--- a/src/align/utils.py
+++ b/src/align/utils.py
@@ -43,8 +43,8 @@ def crop(img, bb, margin):
     x0, y0, x1, y1 = bb[:4]
     margin_height = (y1 - y0) * margin / 2
     margin_width = (x1 - x0) * margin / 2
-    x0 = np.maximum(x0 - margin_width, 0)
-    y0 = np.maximum(y0 - margin_height, 0)
-    x1 = np.minimum(x1 + margin_width, img_width)
-    y1 = np.minimum(y1 + margin_height, img_height)
+    x0 = int(np.maximum(x0 - margin_width, 0))
+    y0 = int(np.maximum(y0 - margin_height, 0))
+    x1 = int(np.minimum(x1 + margin_width, img_width))
+    y1 = int(np.minimum(y1 + margin_height, img_height))
     return  img[y0:y1,x0:x1,:], (x0, y0, x1, y1)

--- a/src/align/utils.py
+++ b/src/align/utils.py
@@ -32,6 +32,12 @@ def crop(img, bb, margin):
     margin = float from 0 to 1 for the amount of margin to add, relative to the
         bounding box dimensions (half margin added to each side)
     """
+    
+    if margin < 0:
+        raise ValueError("the margin must be a value between 0 and 1")
+    if margin > 1:
+        raise ValueError("the margin must be a value between 0 and 1 - this is a change from the existing API")
+    
     img_height = img.shape[0]
     img_width = img.shape[1]
     x0, y0, x1, y1 = bb[:4]

--- a/src/align/utils.py
+++ b/src/align/utils.py
@@ -1,0 +1,44 @@
+# MIT License
+# 
+# Copyright (c) 2016 David Sandberg
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+import numpy as np
+
+def crop(img, bb, margin):
+    """
+    img = image from misc.imread, which should be in (H, W, C) format
+    bb = pixel coordinates of bounding box: (x0, y0, x1, y1)
+    margin = float from 0 to 1 for the amount of margin to add, relative to the
+        bounding box dimensions (half margin added to each side)
+    """
+    img_height = img.shape[0]
+    img_width = img.shape[1]
+    x0, y0, x1, y1 = bb[:4]
+    margin_height = (y1 - y0) * margin / 2
+    margin_width = (x1 - x0) * margin / 2
+    x0 = np.maximum(x0 - margin_width, 0)
+    y0 = np.maximum(y0 - margin_height, 0)
+    x1 = np.minimum(x1 + margin_width, img_width)
+    y1 = np.minimum(y1 + margin_height, img_height)
+    return  img[y0:y1,x0:x1,:], (x0, y0, x1, y1)

--- a/src/compare.py
+++ b/src/compare.py
@@ -35,6 +35,7 @@ import copy
 import argparse
 import facenet
 import align.detect_face
+import align.utils
 
 def main(args):
 
@@ -100,12 +101,7 @@ def load_and_align_data(image_paths, image_size, margin, gpu_memory_fraction):
           print("can't detect face, remove ", image)
           continue
         det = np.squeeze(bounding_boxes[0,0:4])
-        bb = np.zeros(4, dtype=np.int32)
-        bb[0] = np.maximum(det[0]-margin/2, 0)
-        bb[1] = np.maximum(det[1]-margin/2, 0)
-        bb[2] = np.minimum(det[2]+margin/2, img_size[1])
-        bb[3] = np.minimum(det[3]+margin/2, img_size[0])
-        cropped = img[bb[1]:bb[3],bb[0]:bb[2],:]
+        cropped, _ = align.utils.crop(img, det, margin)
         aligned = misc.imresize(cropped, (image_size, image_size), interp='bilinear')
         prewhitened = facenet.prewhiten(aligned)
         img_list.append(prewhitened)
@@ -120,8 +116,8 @@ def parse_arguments(argv):
     parser.add_argument('image_files', type=str, nargs='+', help='Images to compare')
     parser.add_argument('--image_size', type=int,
         help='Image size (height, width) in pixels.', default=160)
-    parser.add_argument('--margin', type=int,
-        help='Margin for the crop around the bounding box (height, width) in pixels.', default=44)
+    parser.add_argument('--margin', type=float,
+        help='Margin for the crop around the bounding box (height, width), as a proportion of the face height/width', default=.4)
     parser.add_argument('--gpu_memory_fraction', type=float,
         help='Upper bound on the amount of GPU memory that will be used by the process.', default=1.0)
     return parser.parse_args(argv)


### PR DESCRIPTION
Motivation is simple: in the 'aligned' faces, they should (for upright faces) be in the center of the image and roughly of the same size. The current approach is to have a fixed margin size before rescaling, which means that for a large face, the 'aligned' face might be e.g. 90% of the image, whereas for a small face, the 'aligned' face might only be 10% of the image. One would suspect that remove this ambiguity may 'improve' the model - as seems supported by #283.

Changes:
- moved to proportional margin specified by a float
- did it in a single `crop` function which gets reused

Severity:
- any scripts running with existing margins (e.g. 44) will break (as I decided to throw an error if the margin is > 1, to prevent the accidental continued use of e.g. `margin=44` which would still run, but give odd results)

Questions:
- currently a margin of `x` means `x/2 * face_width` on each side of the image (and likewise for height). This is to follow the current interpretation, but if there are no objections, I'd prefer to change it to a margin of `x` to mean a margin of `x * face_width` on each side of the image, as that's the usual interpretation of margin, as far as I'm aware.
- if we don't want the breaking changes in the API, I could keep the margin as an int like `44`, and take it to be the margin relative to the image size. E.g. if the image size is `160`, then I'd just treat used `44 / 160` as my margin. Hence it avoids breaking changes, but it is less clear about what it means.