### PR TITLE
Making Facenet more accessible (and faster time to classify) using pre-loaded model + RPC

### DIFF
--- a/contributed/jasonmayes-facenet-rpc-server-node/README.md
+++ b/contributed/jasonmayes-facenet-rpc-server-node/README.md
@@ -15,10 +15,11 @@ I decided to rewrite this to be optimised for web servers such as those running 
 
 Please ensure you change the commented variables near the top of the file to point to files on your system. Namely these are:
 
+```python
 MODEL = "/path/to/model.pb"
 CLASSIFIER_FILENAME = "/path/to/your/classifier.pkl"
 preload_image = "/path/to/some/image.jpg"
-
+```
 The preload_image is needed with some dummy jpg with a face to set the system up once before you make any RPC calls to the Python RPC server.
 
 
@@ -26,8 +27,9 @@ The preload_image is needed with some dummy jpg with a face to set the system up
 
 Ensure you change the following variable to a JPG you want to classify:
 
+```javascript
 var JPG_FILE = '/path/to/file.jpg';
-
+```
 Assuming the Python RPC server is running already and has printed out "Initiation complete" you can now use the example code to make RPC calls to Python from Node.js and it should be pretty fast - I am getting way under 100ms for a classification on a vanilla CPU instance on Google Compute Engine.
 
 Please note that to run this you need to install zerorpc for node - which may need you to compile from source as I had issues using the NPM version. Once that is installed though all should work fine :-)

--- a/contributed/jasonmayes-facenet-rpc-server-node/README.md
+++ b/contributed/jasonmayes-facenet-rpc-server-node/README.md
@@ -1,0 +1,37 @@
+# Face recognition using Tensorflow made easier and faster with a precached model exposed by a Python RPC server for use with Node.js
+
+Reduces time to receiving a classification from around 11 seconds to < 100 ms by preloading trained model and only loading in the jpg for classification at run-time to feed through the preloaded network in Python. Also exposes an RPC server so you can call this Python function from any language you like such as Node.js which is much more common for real world use case on a web server at scale (eg web sockets and such).
+
+
+## Background
+The python code is heavily inspired by the original precict.py code in the directory above this one by the original author. However that file was not useful for general real world useage as it took about 11 seconds to load up the model each time and perform a classification which is less than ideal.
+
+I decided to rewrite this to be optimised for web servers such as those running on Google Compute Engine allowing you to query faces super fast as you get the images from a client to classify in near real time (<100ms) using an remote procedure call to a pre cached model in python by refactoring the original code.
+
+
+## Requirements and notes
+
+### Python
+
+Please ensure you change the commented variables near the top of the file to point to files on your system. Namely these are:
+
+MODEL = "/path/to/model.pb"
+CLASSIFIER_FILENAME = "/path/to/your/classifier.pkl"
+preload_image = "/path/to/some/image.jpg"
+
+The preload_image is needed with some dummy jpg with a face to set the system up once before you make any RPC calls to the Python RPC server.
+
+
+### Node.js
+
+Ensure you change the following variable to a JPG you want to classify:
+
+var JPG_FILE = '/path/to/file.jpg';
+
+Assuming the Python RPC server is running already and has printed out "Initiation complete" you can now use the example code to make RPC calls to Python from Node.js and it should be pretty fast - I am getting way under 100ms for a classification on a vanilla CPU instance on Google Compute Engine.
+
+Please note that to run this you need to install zerorpc for node - which may need you to compile from source as I had issues using the NPM version. Once that is installed though all should work fine :-)
+
+## Questions?
+
+Feel free to [get in touch with Jason Mayes](http://www.jasonmayes.com) if any questions on setting this up in a production environment.

--- a/contributed/jasonmayes-facenet-rpc-server-node/facenet-fast-preload-rpc-predict.py
+++ b/contributed/jasonmayes-facenet-rpc-server-node/facenet-fast-preload-rpc-predict.py
@@ -1,3 +1,10 @@
+#----------------------------------------------------
+#  jasonmayes-facenet-rpc-server-node
+#  By Jason Mayes 2018
+#  www.jasonmayes.com
+#  Github: https://github.com/jasonmayes/facenet
+#----------------------------------------------------
+
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function

--- a/contributed/jasonmayes-facenet-rpc-server-node/facenet-fast-preload-rpc-predict.py
+++ b/contributed/jasonmayes-facenet-rpc-server-node/facenet-fast-preload-rpc-predict.py
@@ -1,5 +1,5 @@
 #----------------------------------------------------
-#  jasonmayes-facenet-rpc-server-node
+#  jasonmayes-facenet-precached-rpc-server
 #  By Jason Mayes 2018
 #  www.jasonmayes.com
 #  Github: https://github.com/jasonmayes/facenet

--- a/contributed/jasonmayes-facenet-rpc-server-node/facenet-fast-preload-rpc-predict.py
+++ b/contributed/jasonmayes-facenet-rpc-server-node/facenet-fast-preload-rpc-predict.py
@@ -1,0 +1,142 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import tensorflow as tf
+import numpy as np
+import facenet
+import os
+import sys
+import math
+import pickle
+import zerorpc
+
+from sklearn.svm import SVC
+from scipy import misc
+import align.detect_face
+from six.moves import xrange
+
+import logging
+logging.basicConfig()
+
+'''
+  Change these two constants to the model and classifier you are using / trained.
+'''
+MODEL = "/path/to/model.pb"
+CLASSIFIER_FILENAME = "/path/to/your/classifier.pkl"
+'''
+  Point to an example image to classify - need one to setup the system once on
+  startup! Change this!
+'''
+preload_image = "/path/to/some/image.jpg"
+
+
+
+MARGIN = 44
+GPU_MEMORY_FRACTION = 1.0
+IMAGE_SIZE = 160
+
+
+bbs = []
+minsize = 20 # minimum size of face
+threshold = [ 0.6, 0.7, 0.7 ]  # three steps's threshold
+factor = 0.709 # scale factor
+
+
+img_li = []
+imgTmp = misc.imread(os.path.expanduser(preload_image))
+img_sz = np.asarray(imgTmp.shape)[0:2]
+
+
+with tf.Graph().as_default():
+    gpu_options = tf.GPUOptions(per_process_gpu_memory_fraction=GPU_MEMORY_FRACTION)
+    sess = tf.Session(config=tf.ConfigProto(gpu_options=gpu_options, log_device_placement=False))
+
+    with sess.as_default():
+        pnet, rnet, onet = align.detect_face.create_mtcnn(sess, None)
+
+        facenet.load_model(MODEL)
+        images_placeholder = tf.get_default_graph().get_tensor_by_name("input:0")
+        embeddings = tf.get_default_graph().get_tensor_by_name("embeddings:0")
+        phase_train_placeholder = tf.get_default_graph().get_tensor_by_name("phase_train:0")
+
+
+    bounding_boxes, _ = align.detect_face.detect_face(imgTmp, minsize, pnet, rnet, onet, threshold, factor)
+        count_per_image = len(bounding_boxes)
+        for j in range(len(bounding_boxes)):
+            det = np.squeeze(bounding_boxes[j,0:4])
+            bb = np.zeros(4, dtype=np.int32)
+            bb[0] = np.maximum(det[0]-MARGIN/2, 0)
+            bb[1] = np.maximum(det[1]-MARGIN/2, 0)
+            bb[2] = np.minimum(det[2]+MARGIN/2, img_sz[1])
+            bb[3] = np.minimum(det[3]+MARGIN/2, img_sz[0])
+            cropped = imgTmp[bb[1]:bb[3],bb[0]:bb[2],:]
+            aligned = misc.imresize(cropped, (IMAGE_SIZE, IMAGE_SIZE), interp='bilinear')
+            prewhitened = facenet.prewhiten(aligned)
+            img_li.append(prewhitened)
+            bbs.append(bounding_boxes[j])
+        images = np.stack(img_li)
+
+        # Run forward pass to calculate embeddings
+        feed_dict = { images_placeholder: images , phase_train_placeholder:False}
+        emb = sess.run(embeddings, feed_dict=feed_dict)
+	print("Initiation complete - you can now call from Node.js using RPC!")
+
+
+class RPCCom(object):
+    def classifyFile(self, file_to_process):
+        # Print to console the file we are dealing with for debugging purposes.
+        print(file_to_process)
+        img_list = []
+        img = misc.imread(os.path.expanduser(file_to_process))
+        img_size = np.asarray(img.shape)[0:2]
+
+        with tf.Graph().as_default():
+            with sess.as_default():
+                bounding_boxes, _ = align.detect_face.detect_face(img, minsize, pnet, rnet, onet, threshold, factor)
+                count_per_image = len(bounding_boxes)
+
+                for j in range(len(bounding_boxes)):
+                    det = np.squeeze(bounding_boxes[j,0:4])
+                    bb = np.zeros(4, dtype=np.int32)
+                    bb[0] = np.maximum(det[0]-MARGIN/2, 0)
+                    bb[1] = np.maximum(det[1]-MARGIN/2, 0)
+                    bb[2] = np.minimum(det[2]+MARGIN/2, img_size[1])
+                    bb[3] = np.minimum(det[3]+MARGIN/2, img_size[0])
+                    cropped = img[bb[1]:bb[3],bb[0]:bb[2],:]
+                    aligned = misc.imresize(cropped, (IMAGE_SIZE, IMAGE_SIZE), interp='bilinear')
+                    prewhitened = facenet.prewhiten(aligned)
+                    img_list.append(prewhitened)
+                    bbs.append(bounding_boxes[j])
+                images = np.stack(img_list)
+
+                # Run forward pass to calculate embeddings
+                feed_dict = { images_placeholder: images , phase_train_placeholder:False}
+                emb = sess.run(embeddings, feed_dict=feed_dict)
+
+                classifier_filename_exp = os.path.expanduser(CLASSIFIER_FILENAME)
+                with open(classifier_filename_exp, 'rb') as infile:
+                    (model, class_names) = pickle.load(infile)
+                print('Loaded classifier model from file "%s"\n' % classifier_filename_exp)
+                predictions = model.predict_proba(emb)
+                best_class_indices = np.argmax(predictions, axis=1)
+                best_class_probabilities = predictions[np.arange(len(best_class_indices)), best_class_indices]
+                #print predictions
+                prediction_str = ""
+                # print("\npeople in image %s :" %(file_to_process))
+                prediction_str = prediction_str + class_names[best_class_indices[0]] + "," + str(best_class_probabilities[0]) + ";"
+
+                # Print Prediction and optional Bounding Boxes...
+                print(prediction_str);
+                # print(bbs)
+
+                return "%s" % prediction_str
+
+
+def main():
+    # Setup RPC server.
+    s = zerorpc.Server(RPCCom())
+    s.bind("tcp://0.0.0.0:4242")
+    s.run()
+
+main()

--- a/contributed/jasonmayes-facenet-rpc-server-node/nodeServer.js
+++ b/contributed/jasonmayes-facenet-rpc-server-node/nodeServer.js
@@ -1,0 +1,14 @@
+var zerorpc = require("zerorpc");
+
+// Change this to a JPG to classify on your server.
+var JPG_FILE = '/path/to/file.jpg';
+
+// Connect to Python RPC server.
+var client = new zerorpc.Client();
+client.connect("tcp://127.0.0.1:4242");
+
+// Invoke remote function call to classify a jpg file of our choice.
+client.invoke("classifyFile", JPG_FILE, function(error, res, more) {
+  // Print out classification.
+  console.log(res.toString('utf8'));
+});


### PR DESCRIPTION
Have added some example code to show how to use Facenet continuously via RPC without the overhead of loading up the model each time reducing time to classify from 11 seconds to < 100 ms. Would be great to contribute so others can then use this in a faster manner and reach a larger audience - namely Node.js developers (but any language that supports RPC would work with the Python server here) - who can then deploy on servers with ease for faster classification.