### PR TITLE
An indentation fix

### DIFF
--- a/src/align/align_dataset_mtcnn.py
+++ b/src/align/align_dataset_mtcnn.py
@@ -71,8 +71,8 @@ def main(args):
             output_class_dir = os.path.join(output_dir, cls.name)
             if not os.path.exists(output_class_dir):
                 os.makedirs(output_class_dir)
-                if args.random_order:
-                    random.shuffle(cls.image_paths)
+            if args.random_order:
+                random.shuffle(cls.image_paths)
             for image_path in cls.image_paths:
                 nrof_images_total += 1
                 filename = os.path.splitext(os.path.split(image_path)[1])[0]


### PR DESCRIPTION
The "random shuffling" of images of within a class SHOULD NOT depend on the existence or generation of the class directory.
Therefore, it should not be indented.  It should be put outside the if-statement of "path existence check" .