### PR TITLE
fix facenet.get_learning_rate_from_file()

### DIFF
--- a/src/facenet.py
+++ b/src/facenet.py
@@ -299,8 +299,7 @@ def get_learning_rate_from_file(filename, epoch):
                     lr = float(par[1])
                 if e <= epoch:
                     learning_rate = lr
-                else:
-                    return learning_rate
+        return learning_rate
 
 class ImageClass():
     "Stores the paths to images for a given class"


### PR DESCRIPTION
I expected when learning rate becomes `-1`, the train is closed
but `get_learning_rate_from_file()` returns `nonetype` whenever learning rate becomes  `-1`
( other users have this problem, too : #853 )
it is the problem, and I modified the function so that solve the problem

_images below show the different results_

before:
![01](https://user-images.githubusercontent.com/29627579/46019144-643d9980-c116-11e8-8cef-62d8b3958c1e.png)

after:
![02](https://user-images.githubusercontent.com/29627579/46019162-6e5f9800-c116-11e8-8a73-36c3fd93c764.png)
