### PR TITLE
Fix to handle orientation Exif data in vertical images, improving alignment

### DIFF
--- a/src/align/align_dataset_mtcnn.py
+++ b/src/align/align_dataset_mtcnn.py
@@ -25,7 +25,9 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-from scipy import misc
+import imageio
+#from scipy import misc
+from PIL import Image
 import sys
 import os
 import argparse
@@ -80,7 +82,7 @@ def main(args):
                 print(image_path)
                 if not os.path.exists(output_filename):
                     try:
-                        img = misc.imread(image_path)
+                        img = imageio.imread(image_path)
                     except (IOError, ValueError, IndexError) as e:
                         errorMessage = '{}: {}'.format(image_path, e)
                         print(errorMessage)
@@ -121,14 +123,14 @@ def main(args):
                                 bb[2] = np.minimum(det[2]+args.margin/2, img_size[1])
                                 bb[3] = np.minimum(det[3]+args.margin/2, img_size[0])
                                 cropped = img[bb[1]:bb[3],bb[0]:bb[2],:]
-                                scaled = misc.imresize(cropped, (args.image_size, args.image_size), interp='bilinear')
+                                scaled = np.array(Image.fromarray(cropped).resize((args.image_size,args.image_size)))
                                 nrof_successfully_aligned += 1
                                 filename_base, file_extension = os.path.splitext(output_filename)
                                 if args.detect_multiple_faces:
                                     output_filename_n = "{}_{}{}".format(filename_base, i, file_extension)
                                 else:
                                     output_filename_n = "{}{}".format(filename_base, file_extension)
-                                misc.imsave(output_filename_n, scaled)
+                                imageio.imwrite(output_filename_n, scaled)
                                 text_file.write('%s %d %d %d %d\n' % (output_filename_n, bb[0], bb[1], bb[2], bb[3]))
                         else:
                             print('Unable to align "%s"' % image_path)

--- a/src/align/align_dataset_mtcnn.py
+++ b/src/align/align_dataset_mtcnn.py
@@ -26,7 +26,6 @@ from __future__ import division
 from __future__ import print_function
 
 import imageio
-#from scipy import misc
 from PIL import Image
 import sys
 import os


### PR DESCRIPTION
The current use of scipy.misc for image reading/writing/resizing in the
implementation of mtcnn will be deprecated with the new version of scipy.  In
addition, (and most motivating for me), the scipy.misc imread function ignores
the image's Orientation Exif flag, meaning vertical images can be read in
rotated, greatly decreasing alignment performance.

This branch converts all scipy.misc functions in align_dataset_mtcnn.py to the
appropriate and suggested equivalents in the imageio package.  This introduces
a new project dependency on imageio, but the orientation data is now
considered and handled appropriately.