### PR TITLE
Fixed assert that always evaluates to True

### DIFF
--- a/src/classifier.py
+++ b/src/classifier.py
@@ -56,7 +56,7 @@ def main(args):
 
             # Check that there are at least one training image per class
             for cls in dataset:
-                assert(len(cls.image_paths)>0, 'There must be at least one image for each class in the dataset')            
+                assert len(cls.image_paths)>0, 'There must be at least one image for each class in the dataset'
 
                  
             paths, labels = facenet.get_image_paths_and_labels(dataset)


### PR DESCRIPTION
Fixes an assert statement in `/src/classifier.py` that always evaluates to True because it asserts on a non-empty tuple

Disclaimer: I work for Semmle and I've found this error using our LGTM code analyzer
https://lgtm.com/projects/g/davidsandberg/facenet/alerts/?mode=tree&ruleFocus=7870115