### PR TITLE
Travis CI: Add flake8 to find Python syntax errors and undefined names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: python
-sudo: required
 python:
   - "2.7"
   - "3.5"
@@ -8,9 +7,10 @@ install:
 # numpy not using wheel to avoid problem described in 
 #  https://github.com/tensorflow/tensorflow/issues/6968
   - pip install --no-binary numpy --upgrade numpy
-  - pip install -r requirements.txt
+  - pip install flake8 -r requirements.txt
 # command to run tests
 script:
+  - flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
   - export PYTHONPATH=./src:./src/models:./src/align
   - python -m unittest discover -s test --pattern=*.py 1>&2
 dist: trusty


### PR DESCRIPTION
Also, the __sudo:__ tag is deprecated on Travis CI.

[flake8](http://flake8.pycqa.org) testing of https://github.com/davidsandberg/facenet on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics__
```
./src/classifier.py:59:17: F631 assertion is always true, perhaps remove parentheses?
                assert(len(cls.image_paths)>0, 'There must be at least one image for each class in the dataset')            
                ^
./src/align/detect_face.py:711:12: F632 use ==/!= to compare str, bytes, and int literals
        if method is 'Min':
           ^
./contributed/cluster.py:124:14: F821 undefined name 'xrange'
    for x in xrange(len(image_list)):
             ^
./contributed/cluster.py:129:22: F821 undefined name 'xrange'
            for i in xrange(nrof_samples):
                     ^
1     F631 assertion is always true, perhaps remove parentheses?
1     F632 use ==/!= to compare str, bytes, and int literals
2     F821 undefined name 'xrange'
4
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree