### PR TITLE
update requirements.txt and detect_face.py for aligning dataset

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 tensorflow==1.7
-scipy
+scipy==1.1.0
 scikit-learn
 opencv-python
 h5py

--- a/src/align/detect_face.py
+++ b/src/align/detect_face.py
@@ -82,7 +82,7 @@ class Network(object):
         session: The current TensorFlow session
         ignore_missing: If true, serialized weights for missing layers are ignored.
         """
-        data_dict = np.load(data_path, encoding='latin1').item() #pylint: disable=no-member
+        data_dict = np.load(data_path, encoding='latin1', allow_pickle=True).item() #pylint: disable=no-member
 
         for op_name in data_dict:
             with tf.variable_scope(op_name, reuse=True):


### PR DESCRIPTION
- Dependency on scipy::1.1.0 for using scipy.misc.imread module
- added `allow_pickle=True` parameter while using np.load to fix : `Object arrays cannot be loaded when allow_pickle=False` error while aligning dataset