### PR TITLE
Fix incompatibilities with the newest libraries

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 tensorflow==1.7
-scipy
+scipy==1.2.1
 scikit-learn
 opencv-python
 h5py
@@ -7,3 +7,4 @@ matplotlib
 Pillow
 requests
 psutil
+numpy==1.16.2


### PR DESCRIPTION
Running `src/align/align_dataset_mtcnn.py` from tutorial https://github.com/davidsandberg/facenet/wiki/Validate-on-LFW
Resulted in the error ```ValueError: Object arrays cannot be loaded when allow_pickle = False```

This is what fixed it:
```
Errors that may be encountered during the execution of the last command
1.ValueError: Object arrays cannot be loaded when allow_pickle = False "Cause numpy version is not 1.16.2 Solution execution 
pip install numpy == 1.16.2
 
2.AttributeError: module 'scipy.misc' has no attribute 'imread' Cause The version of scipy is not 1.2.1 Solution execution   
pip install scipy == 1.2.1
```
Source: https://www.cnblogs.com/kristin-pig/p/11719692.html